### PR TITLE
allow tag selection in update.sh script

### DIFF
--- a/contrib/update.sh
+++ b/contrib/update.sh
@@ -8,10 +8,13 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
+COMMITID="${1:-master}"
+
 set -e
 #set -x
 
-git pull origin master --tags
+git fetch origin --tags
+git checkout "$COMMITID"
 npm ci
 poetry install --only main
 poetry run python manage.py collectstatic --no-input


### PR DESCRIPTION
#### What does it do?

Permit tag selection in `contrib/update.sh` update script

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
