### PR TITLE
reworked docker build for theme and rootless run

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,28 +16,36 @@ ENV APP_VERSION=$APP_VERSION
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  gettext \
+  && rm -rf /var/lib/apt/lists/*
+
+# running as www-data, we need homedir and PATH for --user installed pip modules
+RUN mkdir -p /app /var/www && chown www-data: /app /var/www
+ENV PATH="${PATH}:/var/www/.local/bin"
+USER www-data
+
 # because package.json scripts.postinstall tries to be smart
-COPY --from=npmbuilder /app/node_modules /app/static/npm_components
+COPY --chown=www-data --from=npmbuilder /app/node_modules /app/static/npm_components
 
-COPY governanceplatform /app/governanceplatform
-COPY incidents /app/incidents
-COPY locale /app/locale
-COPY static /app/static
-COPY templates /app/templates
+COPY --chown=www-data governanceplatform /app/governanceplatform
+COPY --chown=www-data incidents /app/incidents
+COPY --chown=www-data locale /app/locale
+COPY --chown=www-data static /app/static
+COPY --chown=www-data templates /app/templates
 
-COPY pyproject.toml /app/pyproject.toml
-COPY README.md /app/README.md
-COPY manage.py /app/manage.py
+COPY --chown=www-data pyproject.toml /app/pyproject.toml
+COPY --chown=www-data README.md /app/README.md
+COPY --chown=www-data manage.py /app/manage.py
 
-COPY contrib/cronjob.sh /app/cronjob.sh
+COPY --chown=www-data contrib/cronjob.sh /app/cronjob.sh
 
-RUN python3 -m pip install .
-RUN python3 -m pip install gunicorn~=$GUNICORN_VERSION
-
-RUN apt-get update && apt-get install -y gettext && apt-get clean
+RUN python3 -m pip install --user .
+RUN python3 -m pip install --user gunicorn~=$GUNICORN_VERSION
 
 COPY docker/docker-init.sh /app/docker-init.sh
-CMD /app/docker-init.sh
+
+ENTRYPOINT [ "/app/docker-init.sh" ]
 
 ENV APP_PORT="8888"
 ENV APP_BIND_ADDRESS="127.0.0.1"

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,6 +10,10 @@ network mode to ease database and MTA/mail access
 
 ## Volumes
 
+> Please note that the container runs as user `www-data` (uid **33**), so at
+> least the `theme`, `static` and `logs` volumes **need** to be owned by
+> `www-data` (uid **33**)
+
 There are four volumes to setup:
 
 - `/app/governanceplatform/config.py`  
@@ -20,15 +24,26 @@ There are four volumes to setup:
   `github.com/informed-governance-project/default-theme`, that may change in the
   future or if you wish to use a custom theme for your needs.
   This directory needs to be writable as translation files (.po) are written
-  there at application start up.
+  there at application start up. Most of the time specific version of this
+  application will require specific version of the theme - please ask your
+  theme developper which theme version you should use.
 
 - `/app/governanceplatform/static`  
-  A writable directory were Django can collect static assets, this directory
+  A writable directory where Django can collect static assets, this directory
   should be served by your reverse proxy/web server (see
   `docker/apache2-example.conf` for an reverse proxy configuration example)
 
 - `/app/governanceplatform/logs`  
   A writable location for logs (if you configure logging through files)
+
+## Startup scripts
+
+Any `*.sh` script found under `/docker-init.d/` will be *sourced* before the
+various static assets generation, Django migration etc ... this directory can
+be exposed as a Docker volume also.
+
+This allows application deployers to inject/fix anything they deem necessary
+before the actual Django runtime init and application startup.
 
 ## Startup
 

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -6,6 +6,7 @@ services:
     network_mode: host
     volumes:
       - ./volumes/config/config.py:/app/governanceplatform/config.py:ro
+      # the three below need to be writable by www-data (uid 33)
       - ./volumes/default-theme:/app/theme
       - ./volumes/static:/app/governanceplatform/static
       - ./volumes/logs:/app/governanceplatform/logs

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -1,6 +1,13 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -euo pipefail
+
+docker_init_d=/docker-init.d
+if [ -d $docker_init_d -a $docker_init_d/*.sh != "${docker_init_d}/*.sh" ]; then
+    for f in $docker_init_d/*.sh; do
+        source "$f"
+    done
+fi
 
 python manage.py collectstatic --noinput > /dev/null
 python manage.py migrate


### PR DESCRIPTION
#### What does it do?

- theme is external volume again
- container runs as www-data uid 33
- fix in the entrypoint and exec scheme, gunicorn now PID 1
- add /docker-init.d/*.sh support for early init by user
- updated documentation

#### Questions

- [ ] Does it require a DB change? no
- [ ] Are you using it in production? not at the moment

#### Release Type:
- [ ] Major
- [X] Minor
- [ ] Patch
